### PR TITLE
Add atomic to link_libraries - fixes compilation on ArchLinux ARM with GCC8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,4 +230,4 @@ endif()
 
 add_executable(fbcp-ili9341 ${sourceFiles})
 
-target_link_libraries(fbcp-ili9341 pthread bcm_host)
+target_link_libraries(fbcp-ili9341 pthread bcm_host atomic)


### PR DESCRIPTION
Hi,

the title already says it all. :) 
This fixes the compilation on ArchLinux ARM with modern GCC versions. 
Shouldn't have negative side effects on Debian.

Tobias