### PR TITLE
Set DMA channels from arguments

### DIFF
--- a/dma.cpp
+++ b/dma.cpp
@@ -25,8 +25,10 @@ volatile DMAChannelRegisterFile *dmaTx = 0;
 volatile DMAChannelRegisterFile *dmaRx = 0;
 int dmaTxChannel = -1;
 int dmaTxIrq = 0;
+extern int dmaTxChannelcustom; //nns: allow set dma channels from arguments
 int dmaRxChannel = -1;
 int dmaRxIrq = 0;
+extern int dmaRxChannelcustom; //nns: allow set dma channels from arguments
 
 #define PAGE_SIZE 4096
 
@@ -93,6 +95,10 @@ static int AllocateDMAChannel(int *dmaChannel, int *irq)
 #if defined(DMA_RX_CHANNEL)
   freeChannels[1] = DMA_RX_CHANNEL;
 #endif
+  
+  if(dmaTxChannelcustom!=-1){freeChannels[0] = dmaTxChannelcustom;} //nns: allow set dma channels from arguments
+  if(dmaRxChannelcustom!=-1){freeChannels[1] = dmaRxChannelcustom;} //nns: allow set dma channels from arguments
+  
   if (freeChannels[0] == freeChannels[1]) FATAL_ERROR("DMA TX and RX channels cannot be the same channel!");
 
   static int nextFreeChannel = 0;

--- a/fbcp-ili9341.cpp
+++ b/fbcp-ili9341.cpp
@@ -47,6 +47,9 @@ int CountNumChangedPixels(uint16_t *framebuffer, uint16_t *prevFramebuffer)
 uint64_t displayContentsLastChanged = 0;
 bool displayOff = false;
 
+int dmaTxChannelcustom = -1; //nns: allow set dma channels from arguments
+int dmaRxChannelcustom = -1; //nns: allow set dma channels from arguments
+
 volatile bool programRunning = true;
 
 const char *SignalToString(int signal)
@@ -88,8 +91,17 @@ void ProgramInterruptHandler(int signal)
   syscall(SYS_futex, &numNewGpuFrames, FUTEX_WAKE, 1, 0, 0, 0);
 }
 
-int main()
+#ifndef KERNEL_MODULE
+int main( int argc, char *argv[] ) 
 {
+	for(int i=1;i<argc;++i){ //nns: allow set dma channels from arguments
+		if(strcmp(argv[i],"-DMA_TX_CHANNEL")==0){dmaTxChannelcustom=atoi(argv[i+1]);
+		}else if(strcmp(argv[i],"-DMA_RX_CHANNEL")==0){dmaRxChannelcustom=atoi(argv[i+1]);}
+	}
+#else
+int main() 
+{
+#endif
   signal(SIGINT, ProgramInterruptHandler);
   signal(SIGQUIT, ProgramInterruptHandler);
   signal(SIGUSR1, ProgramInterruptHandler);

--- a/freeplaytech_waveshare32b.h
+++ b/freeplaytech_waveshare32b.h
@@ -16,9 +16,9 @@
 // Effective display area is then 320-18=302 pixels horizontally, and 202 pixels vertically (in landscape direction).
 
 // The meaning of top/left/right/bottom here should be interpreted as the display being oriented in its native direction (which is portrait mode for ILI9341, 240x320 direction).
-#define DISPLAY_NATIVE_COVERED_TOP_SIDE 18
-#define DISPLAY_NATIVE_COVERED_LEFT_SIDE 9
-#define DISPLAY_NATIVE_COVERED_RIGHT_SIDE 29
-#define DISPLAY_NATIVE_COVERED_BOTTOM_SIDE 0
+#define DISPLAY_NATIVE_COVERED_TOP_SIDE 18 //left on FreePlayTech devices
+#define DISPLAY_NATIVE_COVERED_LEFT_SIDE 9 //top on FreePlayTech devices
+#define DISPLAY_NATIVE_COVERED_RIGHT_SIDE 29 //bottom on FreePlayTech devices
+#define DISPLAY_NATIVE_COVERED_BOTTOM_SIDE 0 //right on FreePlayTech devices
 
 #endif


### PR DESCRIPTION
This PR allow user to set DMA channels from arguments when not running in Kernel driver mode.
Example : ./build/fbcp-ili9341 -DMA_TX_CHANNEL 2 -DMA_RX_CHANNEL 5

Also add comment for screen side in freeplaytech_waveshare32b.h