### PR TITLE
DISPLAY_SWAP_BGR was not swapping colours, according to pg 192 of (In…

### DIFF
--- a/ili9341.cpp
+++ b/ili9341.cpp
@@ -61,6 +61,8 @@ void InitILI9341()
 #ifdef DISPLAY_ROTATE_180_DEGREES
     madctl ^= MADCTL_ROTATE_180_DEGREES;
 #endif
+    // The set value of MADCTL is the exclusive OR between 1st param of IFCTL and MADCTL, see spec pg. 192
+    SPI_TRANSFER(0xF6/*IFCTL: Interface Control*/, (uint8_t) ~madctl);
     SPI_TRANSFER(0x36/*MADCTL: Memory Access Control*/, madctl);
 
 #ifdef DISPLAY_INVERT_COLORS

--- a/ili9341.cpp
+++ b/ili9341.cpp
@@ -62,7 +62,7 @@ void InitILI9341()
     madctl ^= MADCTL_ROTATE_180_DEGREES;
 #endif
     // The set value of MADCTL is the exclusive OR between 1st param of IFCTL and MADCTL, see spec pg. 192
-    SPI_TRANSFER(0xF6/*IFCTL: Interface Control*/, (uint8_t) ~madctl);
+    SPI_TRANSFER(0xF6/*IFCTL: Interface Control*/, 0);
     SPI_TRANSFER(0x36/*MADCTL: Memory Access Control*/, madctl);
 
 #ifdef DISPLAY_INVERT_COLORS


### PR DESCRIPTION
…terface Control), MADCTL is set to XOR of IFCTL and MADCTL, setting 0 to IFCTL before MADCTL is set to ensure passed MADCTL byte is set.

Was having issues with BGR colours on my Pi Zero and generic ILI9341, I believe this is the root of the issue. Fixed it for me.