### PR TITLE
Update CMakefile.txt for supporting 32bit compile on 64bit OS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,13 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
+if (NOT DEFINED TARGET_ABI)
+  set(TARGET_ABI "linux-gnueabihf")
+endif ()
+# specify the cross compiler
+SET(CMAKE_C_COMPILER   arm-${TARGET_ABI}-gcc)
+SET(CMAKE_CXX_COMPILER arm-${TARGET_ABI}-g++)
+
 include_directories(/opt/vc/include)
 link_directories(/opt/vc/lib)
 


### PR DESCRIPTION
TARGET_ABI can compile these sources by 32bit binary on 64bit OS. The following additional packages are required for 32bit compiling

sudo apt install binutils-arm-linux-gnueabihf g++-arm-linux-gnueabihf

If you get the following lib missing error, 

cannot find -lbcm_host

you can make it by updating rpi-firmware with the command

sudo apt install rpi-update
sudo rpi-update