### PR TITLE
Fully tested for aarch64 OS without a bus error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
+EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
+message( STATUS "Architecture: ${ARCHITECTURE}" )
+
 include_directories(/opt/vc/include)
 link_directories(/opt/vc/lib)
 
@@ -46,7 +49,11 @@ if (SINGLE_CORE_BOARD)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSINGLE_CORE_BOARD=1")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -marm -mabi=aapcs-linux -mhard-float -mfloat-abi=hard -mlittle-endian -mtls-dialect=gnu2 -funsafe-math-optimizations")
+if (NOT ${ARCHITECTURE} STREQUAL "aarch64") 
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -marm -mabi=aapcs-linux -mhard-float -mfloat-abi=hard -mlittle-endian -mtls-dialect=gnu2 -funsafe-math-optimizations")
+else()
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mlittle-endian -funsafe-math-optimizations")
+endif() 
 
 option(ARMV6Z "Target a Raspberry Pi with ARMv6Z instruction set (Pi 1A, 1A+, 1B, 1B+, Zero, Zero W)" ${DEFAULT_TO_ARMV6Z})
 if (ARMV6Z)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,10 +49,10 @@ if (SINGLE_CORE_BOARD)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSINGLE_CORE_BOARD=1")
 endif()
 
-if (NOT ${ARCHITECTURE} STREQUAL "aarch64") 
+if (NOT ${ARCHITECTURE} STREQUAL "aarch64")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -marm -mabi=aapcs-linux -mhard-float -mfloat-abi=hard -mlittle-endian -mtls-dialect=gnu2 -funsafe-math-optimizations")
 else()
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mlittle-endian -funsafe-math-optimizations")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mlittle-endian -funsafe-math-optimizations -mstrict-align")
 endif() 
 
 option(ARMV6Z "Target a Raspberry Pi with ARMv6Z instruction set (Pi 1A, 1A+, 1B, 1B+, Zero, Zero W)" ${DEFAULT_TO_ARMV6Z})

--- a/spi.cpp
+++ b/spi.cpp
@@ -49,8 +49,11 @@ volatile SPIRegisterFile *spi = 0;
 
 // Points to the system timer register. N.B. spec sheet says this is two low and high parts, in an 32-bit aligned (but not 64-bit aligned) address. Profiling shows
 // that Pi 3 Model B does allow reading this as a u64 load, and even when unaligned, it is around 30% faster to do so compared to loading in parts "lo | (hi << 32)".
+#if __aarch64__
+volatile uint32_t *systemTimerRegister = 0;
+#else
 volatile uint64_t *systemTimerRegister = 0;
-
+#endif
 void DumpSPICS(uint32_t reg)
 {
   PRINT_FLAG(BCM2835_SPI0_CS_CS);
@@ -515,7 +518,11 @@ int InitSPI()
   if (bcm2835 == MAP_FAILED) FATAL_ERROR("mapping /dev/mem failed");
   spi = (volatile SPIRegisterFile*)((uintptr_t)bcm2835 + BCM2835_SPI0_BASE);
   gpio = (volatile GPIORegisterFile*)((uintptr_t)bcm2835 + BCM2835_GPIO_BASE);
+  #if __aarch64__
+  systemTimerRegister = (volatile uint32_t*)((uintptr_t)bcm2835 + BCM2835_TIMER_BASE + 0x04); // Generates an unaligned 64-bit pointer, but seems to be fine.
+  #else
   systemTimerRegister = (volatile uint64_t*)((uintptr_t)bcm2835 + BCM2835_TIMER_BASE + 0x04); // Generates an unaligned 64-bit pointer, but seems to be fine.
+  #endif
   // TODO: On graceful shutdown, (ctrl-c signal?) close(mem_fd)
 #endif
 

--- a/tick.h
+++ b/tick.h
@@ -5,11 +5,14 @@
 #include <unistd.h>
 
 // Initialized in spi.cpp along with the rest of the BCM2835 peripheral:
+#if __aarch64__
+extern volatile uint32_t *systemTimerRegister;
+#define tick() (*systemTimerRegister+((uint64_t)(*(systemTimerRegister+1))<<32))
+#else
 extern volatile uint64_t *systemTimerRegister;
 #define tick() (*systemTimerRegister)
-
 #endif
-
+#endif 
 
 #ifdef NO_THROTTLING
 #define usleep(x) ((void)0)


### PR DESCRIPTION
aarch64 architecture is for 64bit OS.
It doesn't allow the 32bit compiler option like -marm -mabi=aapcs-linux -mhard-float -mfloat-abi=hard
So I've replaced them to 64bit compiler option.
Unfortunately BCM2835_TIMER_BASE is not an aligned 64bit address. Therefore we can use 64bit address directly.
It's fixed by calculating upper 32bit and lower 32bit value respectively.
There is no more any bus error after applying this patches.
 

